### PR TITLE
Adding import to use Invoke-SqlCmdWithRetry

### DIFF
--- a/Learning Modules/Schema Management/Deploy-JobAccount.ps1
+++ b/Learning Modules/Schema Management/Deploy-JobAccount.ps1
@@ -19,6 +19,7 @@ param(
 
 $ErrorActionPreference = "Stop" 
 
+Import-Module "$PSScriptRoot\..\Common\CatalogAndDatabaseManagement" -Force
 Import-Module "$PSScriptRoot\..\Common\SubscriptionManagement" -Force
 Import-Module "$PSScriptRoot\..\WtpConfig" -Force
 


### PR DESCRIPTION
When starting from complete scratch after deploying the Azure ARM Template via the deploy button the "Deploy-JobAccount" script would fail as the "Invoke-SqlCmdWithRetry" function was not in scope. I added an import to the script to pull in the CatalogAndDatabaseManagement module which included the cmdlet. After that the Deploy-JobAccount would work.